### PR TITLE
chore: remove RTK

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ No module-level `AGENTS.md` files. Every folder is small (one or a few config fi
 Three git identities are selected purely by clone directory via `includeIf` (git/gitconfig:10-16): `~/dev/` → personal, `~/work/adobe/` → adobe, `~/work/corp/` → corp. Plain `github.com` over SSH resolves to the **Adobe** key because most clones are work repos; personal clones must use the `github-personal` host alias (git/README.md, ssh/README.md). Cloning a personal repo with plain `github.com` gives it the wrong identity and signing key.
 
 ### apply.sh partial failures are intentional, not bugs
-`brew bundle` failures (e.g. Mac App Store `mas` apps that need interactive sign-in) and plugin/RTK init failures are caught and downgraded to warnings so the rest of setup proceeds (apply.sh:104-113, 145-161). Preserve this — do not "fix" it by making these steps fatal.
+`brew bundle` failures (e.g. Mac App Store `mas` apps that need interactive sign-in) and plugin init failures are caught and downgraded to warnings so the rest of setup proceeds (apply.sh:90-100, 132-137). Preserve this — do not "fix" it by making these steps fatal.
 
 ### Pinned formula overrides via a local tap
 `homebrew/legacy-tap/Formula/*.rb` holds pinned formula overrides (e.g. `zbar` pinned to 0.23.90 — 0.23.93 segfaults on Apple Silicon, Brewfile:28). `apply.sh` materializes these into a local Homebrew tap `local/legacy` (apply.sh:64-73) before `brew bundle`. Edit the `.rb` under `homebrew/legacy-tap/`, never the generated tap copy.

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -12,7 +12,7 @@ These are non-negotiable. Violations require explicit human sign-off.
 ## Idempotency of apply.sh
 
 - `apply.sh` must stay idempotent — safe to run any number of times with the same result. Every operation checks current state first: `brew bundle` skips installed packages, `link_file` leaves already-correct symlinks in place (apply.sh:44-51), and `ensure_local_file` creates local files only when missing (apply.sh:53-62). — *Enforced by: human review*
-- `apply.sh` runs under `set -euo pipefail`. Steps that can legitimately fail on a fresh machine (App Store auth, plugin/RTK init) must degrade gracefully — warn and continue — rather than abort the run, matching the existing pattern (apply.sh:104-113, 147-149). — *Enforced by: human review*
+- `apply.sh` runs under `set -euo pipefail`. Steps that can legitimately fail on a fresh machine (App Store auth, plugin init) must degrade gracefully — warn and continue — rather than abort the run, matching the existing pattern (apply.sh:90-100, 132-137). — *Enforced by: human review*
 
 ## File Format
 

--- a/apply.sh
+++ b/apply.sh
@@ -136,17 +136,6 @@ if command -v claude >/dev/null 2>&1; then
   done
 fi
 
-if command -v rtk >/dev/null 2>&1; then
-  echo "→ Initializing RTK proxy for installed AI agents (global token-saving hooks)..."
-  export RTK_TELEMETRY_DISABLED=1
-  if command -v claude >/dev/null 2>&1; then
-    rtk init -g --auto-patch || echo "  ⚠ Failed to initialize RTK for Claude Code — run manually later with: rtk init -g --auto-patch"
-  fi
-  if command -v copilot >/dev/null 2>&1; then
-    rtk init -g --copilot --auto-patch || echo "  ⚠ Failed to initialize RTK for GitHub Copilot CLI — run manually later with: rtk init -g --copilot --auto-patch"
-  fi
-fi
-
 echo "→ Creating local config files (not version-controlled)..."
 ensure_local_file "$DOTFILES_DIR/local/.zshrc-local"      "$HOME/.zshrc.local"
 ensure_local_file "$DOTFILES_DIR/local/.aliases-local"    "$HOME/.aliases.local"

--- a/claude/README.md
+++ b/claude/README.md
@@ -6,9 +6,9 @@ Claude Code configuration.
 |----------------|---------------------------|-------------------------|
 | `statusline.sh`| `~/.claude/statusline.sh` | Claude Code status line |
 
-## Plugins & RTK (via `apply.sh`)
+## Plugins (via `apply.sh`)
 
-`apply.sh` installs code-intelligence and GitHub plugins (`jdtls-lsp`, `kotlin-lsp`, `rust-analyzer-lsp`, `typescript-lsp`, `pyright-lsp`, `github`) and initializes the [RTK](https://www.rtk-ai.app/) token-saving proxy globally. Telemetry is disabled via `RTK_TELEMETRY_DISABLED=1` (set in `shell/zshrc`).
+`apply.sh` installs code-intelligence and GitHub plugins (`jdtls-lsp`, `kotlin-lsp`, `rust-analyzer-lsp`, `typescript-lsp`, `pyright-lsp`, `github`).
 
 ## Enable the status line
 

--- a/copilot/README.md
+++ b/copilot/README.md
@@ -5,5 +5,3 @@
 | `lsp-config.json` | `~/.copilot/lsp-config.json` | LSP servers for the Copilot CLI |
 
 Points the Copilot CLI at the locally installed language servers ([../homebrew/README.md](../homebrew/README.md)) so it can validate syntax without running full compilers.
-
-`apply.sh` also initializes the [RTK](https://www.rtk-ai.app/) proxy for the Copilot CLI (telemetry off via `RTK_TELEMETRY_DISABLED=1` in `shell/zshrc`).

--- a/homebrew/Brewfile
+++ b/homebrew/Brewfile
@@ -62,9 +62,6 @@ brew "azure/kubelogin/kubelogin"
 # Docker
 brew "dive"
 
-# Claude Code RTK proxy
-brew "rtk"
-
 # Mac App Store CLI (required for mas entries below)
 brew "mas"
 

--- a/shell/zshrc
+++ b/shell/zshrc
@@ -24,11 +24,6 @@ export PATH="$HOME/.local/bin:$PATH"
 export CLAUDE_CODE_DISABLE_MOUSE=1
 
 # -------------------------
-# RTK proxy — always disable telemetry
-# -------------------------
-export RTK_TELEMETRY_DISABLED=1
-
-# -------------------------
 # Version manager (mise) — JDK/Python/Rust/etc.
 # -------------------------
 if command -v mise >/dev/null 2>&1; then


### PR DESCRIPTION
RTK was useful for a while, but newer agent versions know how to parse cli output more efficiently now.
I have seen Claude struggle with RTK compressed output, re-running the same commands multiple times expecting specific output realizing that it was RTK that stripped certain characters so the regex never matched.